### PR TITLE
Fix typo in warning message

### DIFF
--- a/lib/pyfits/card.py
+++ b/lib/pyfits/card.py
@@ -515,7 +515,7 @@ class Card(_Verify):
                     # also displayed
                     warnings.warn(
                         'Keyword name %r is greater than 8 characters or '
-                        'or contains characters not allowed by the FITS '
+                        'contains characters not allowed by the FITS '
                         'standard; a HIERARCH card will be created.' %
                         keyword, VerifyWarning)
             else:


### PR DESCRIPTION
Same change as astropy/astropy@afb0c6f8796dfca3eb271531e3f4368bd0766aff in astropy.fits
