### PR TITLE
Deprecate PyFITS for good in a last 3.5 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,13 @@
 Changelog
-===========
+=========
 
 3.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+This release officially deprecates PyFITS. Please use astropy.io.fits instead.
+
+- Importing PyFITS now gives deprecation warning.
+- Documentation updates.
 
 
 3.4 (2016-01-28)
@@ -2962,7 +2965,7 @@ The following enhancements were made:
     stpyfits.
 
 - Added a new feature to allow trailing HDUs to be deleted from a fits file
-  without actually reading the data from the file. 
+  without actually reading the data from the file.
 
   - This supports a JWST requirement to delete a trailing HDU from a file
     whose primary Image HDU is too large to be read on a 32 bit machine.
@@ -3169,7 +3172,7 @@ Changes since v0.9.0:
   binary table.  At the user interface, they are converted to Boolean arrays
   for easy manipulation.  For example, if the column's TFORM is "11X",
   internally the data is stored in 2 bytes, but the user will see, at each row
-  of this column, a Boolean array of 11 elements. 
+  of this column, a Boolean array of 11 elements.
 
 - Fix a bug such that when a table extension has no data, it will not try to
   scale the data when updating/writing the HDU list.
@@ -3260,19 +3263,19 @@ Changes since 0.7.5:
 - Change some internal variables to make their appearance more consistent:
 
     old name                new name
-        
+
     __octalRegex            _octalRegex
     __readblock()           _readblock()
     __formatter()           _formatter().
     __value_RE              _value_RE
-    __numr                  _numr 
-    __comment_RE            _comment_RE 
-    __keywd_RE              _keywd_RE 
+    __numr                  _numr
+    __comment_RE            _comment_RE
+    __keywd_RE              _keywd_RE
     __number_RE             _number_RE.
     tmpName()               _tmpName()
     dimShape                _dimShape
     ErrList                 _ErrList
-   
+
 - Move up the module description.  Move the copywright statement to the bottom
   and assign to the variable __credits__.
 
@@ -3280,7 +3283,7 @@ Changes since 0.7.5:
 
     self.__dict__ = input.__dict__
 
-  to 
+  to
 
     self.__setstate__(input.__getstate__())
 
@@ -3352,12 +3355,12 @@ Changes since v0.7.2:
 0.7.2.1 (2002-06-25)
 ----------------------
 
-A couple of bugs were addressed in this version. 
+A couple of bugs were addressed in this version.
 
 - Fix a bug in _add_commentary(). Due to a change in index_of() during version
   0.6.5.5, _add_commentary needs to be modified to avoid exception if the key
   is not present in the header already. This affects (fixes) add_history(),
-  add_comment(), and add_blank(). 
+  add_comment(), and add_blank().
 
 - Fix a bug in __getattr__() in Card class. The change made in 0.7.2 to rstrip
   the comment must be string type to avoid exception.
@@ -3366,67 +3369,67 @@ A couple of bugs were addressed in this version.
 0.7.2 (2002-06-19)
 --------------------
 
-The two major improvements from Version 0.6.2 are: 
+The two major improvements from Version 0.6.2 are:
 
 - support reading tables  with "scaled" columns (e.g.  tscal/tzero, Boolean,
   and ASCII tables)
 
 - a prototype output verification.
 
-This version of PyFITS requires numarray version 0.3.4. 
+This version of PyFITS requires numarray version 0.3.4.
 
-Other changes include: 
+Other changes include:
 
 - Implement the new HDU hierarchy proposed earlier this year.  This in turn
-  reduces some of the redundant methods common to several HDU classes. 
- 
+  reduces some of the redundant methods common to several HDU classes.
+
 - Add 3 new methods to the Header class: add_history, add_comment, and
   add_blank.
 
 - The table attributes _columns are now .columns and the attributes in ColDefs
   are now all without the underscores.  So, a user can get a list of column
-  names by: hdu.columns.names. 
+  names by: hdu.columns.names.
 
 - The "fill" argument in the new_table method now has a new meaning:<br> If
   set to true (=1), it will fill the entire new table with zeros/blanks.
   Otherwise (=0), just the extra rows/cells are filled with zeros/blanks.
-  Fill values other than zero/blank are now not possible. 
+  Fill values other than zero/blank are now not possible.
 
 - Add the argument output_verify to the open method and writeto method.  Not
-  in the flush or close methods yet, due to possible complication. 
+  in the flush or close methods yet, due to possible complication.
 
 - A new copy method for tables, the copy is totally independent from the table
-  it copies from. 
+  it copies from.
 
 - The tostring() call in writeHDUdata takes up extra space to store the string
-  object.  Use tofile() instead, to save space. 
+  object.  Use tofile() instead, to save space.
 
 - Make changes from _byteswap to _byteorder, following corresponding changes
-  in numarray and recarray. 
+  in numarray and recarray.
 
-- Insert(update) EXTEND in PrimaryHDU only when header is None. 
+- Insert(update) EXTEND in PrimaryHDU only when header is None.
 
-- Strip the trailing blanks for the comment value of a card. 
+- Strip the trailing blanks for the comment value of a card.
 
 - Add seek(0) right after the __buildin__.open(0), because for the 'ab+' mode,
   the pointer is at the end after open in Linux, but it is at the beginning in
-  Solaris. 
+  Solaris.
 
 - Add checking of data against header, update header keywords (NAXIS's,
-  BITPIX) when they don't agree with the data. 
+  BITPIX) when they don't agree with the data.
 
-- change version to __version__. 
+- change version to __version__.
 
 There are also many other minor internal bug fixes and
-technical changes. 
+technical changes.
 
 
 0.6.2 (2002-02-12)
 --------------------
 
-This version requires numarray version 0.2. 
+This version requires numarray version 0.2.
 
-Things not yet supported but are part of future development: 
+Things not yet supported but are part of future development:
 
 - Verification and/or correction of FITS objects being written to disk so that
   they are legal FITS. This is being added now and should be available in
@@ -3452,4 +3455,3 @@ Things not yet supported but are part of future development:
 
 - Support for tables with TNULL values. This awaits an enhancement to numarray
   to support mask arrays (planned).  (At least a couple of months off).
-

--- a/README.txt
+++ b/README.txt
@@ -2,16 +2,14 @@
 Important notice for PyFITS
 ---------------------------
 
-**PyFITS is Deprecated and no longer supported! This repo is
+**PyFITS is deprecated and no longer supported! This repo is
 archived.**
 
-All of the functionality of PyFITS is now available in `Astropy
+All of the functionality of PyFITS is available in `Astropy
 <http://www.astropy.org>`_ as the `astropy.io.fits
-<http://docs.astropy.org/en/stable/io/fits/index.html>`_ package, which is now
-publicly available. We will NOT be releasing new versions of PyFITS as 
-a stand-alone product. STScI will continue to provide support for
-questions on the ``astropy.io.fits package`` in
-Astropy.
+<http://docs.astropy.org/en/stable/io/fits/index.html>`_ package.
+We will NOT be releasing new versions of PyFITS as
+a stand-alone product.
 
 --------------------
 ARCHIVAL INFORMATION

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,15 @@ PyFITS Documentation
 Introduction
 ************
 
+.. warning::
+
+
+    **PyFITS is deprecated and no longer supported!**
+
+    All of the functionality of PyFITS is available in `Astropy
+    <http://www.astropy.org>`_ as the `astropy.io.fits
+    <http://docs.astropy.org/en/stable/io/fits/index.html>`_ package.
+
 The PyFITS module is a Python library providing access to FITS files. FITS
 (Flexible Image Transport System) is a portable file standard widely used in
 the astronomy community to store images and tables.
@@ -834,4 +843,3 @@ Reference/API
 
     users_guide/users_guide
     api_docs/api_docs
-

--- a/pyfits/__init__.py
+++ b/pyfits/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import division
 
+import warnings
+
 try:
     from .version import __version__
 except:
@@ -15,6 +17,9 @@ from .util import *
 __doc__ = core.__doc__
 
 __all__ = core.__all__
+
+warnings.warn('PyFITS is deprecated, please use astropy.io.fits',
+              PyFITSDeprecationWarning)  # noqa
 
 
 try:

--- a/pyfits/util.py
+++ b/pyfits/util.py
@@ -41,6 +41,12 @@ elif six.PY2:
     cmp = cmp
 
 
+class PyFITSDeprecationWarning(Warning):
+    """
+    A warning class to indicate a deprecated feature.
+    """
+
+
 class NotifierMixin(object):
     """
     Mixin class that provides services by which objects can register

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,15 @@
 [metadata]
 name = pyfits
-version = 3.5.dev
+version = 3.5
 author = J. C. Hsu, Paul Barrett, Christopher Hanley, James Taylor,
     Michael Droettboom, Erik M. Bray
 author-email = help@stsci.edu
 summary = Reads FITS images and tables into numpy arrays and manipulates FITS headers
-description-file = 
+description-file =
     README.txt
     CHANGES.txt
-home-page = http://www.stsci.edu/resources/software_hardware/pyfits
-classifier = 
+home-page = http://pyfits.readthedocs.io/en/latest/
+classifier =
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
@@ -18,12 +18,12 @@ classifier =
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Software Development :: Libraries :: Python Modules
 requires-python = >=2.6
-requires-dist = 
+requires-dist =
     numpy
 
 
 [files]
-packages = 
+packages =
     pyfits
     pyfits._compat
     pyfits._compat._odict_py2
@@ -32,16 +32,16 @@ packages =
     pyfits.hdu
     pyfits.scripts
     pyfits.tests
-package_data = 
+package_data =
     pyfits.tests = data/*.fits
-scripts = 
+scripts =
     scripts/fitscheck
     scripts/fitsdiff
     scripts/fitshead
 
 
 [extension=pyfits.compression]
-sources = 
+sources =
 # Comment out or remove all of the cextern/cfitsio/* files when building with
 # the system CFITSIO
     cextern/cfitsio/adler32.c
@@ -116,7 +116,7 @@ sources =
     cextern/cfitsio/zuncompress.c
     cextern/cfitsio/zutil.c
     src/compressionmodule.c
-include_dirs = 
+include_dirs =
     numpy
 # Comment out or remove the following line when building witht he system
 # CFITSIO
@@ -134,7 +134,7 @@ extra_compile_args =
 # Uncomment this line when building with the system CFITSIO
 #libraries = cfitsio
 optional = True
-fail_message = 
+fail_message =
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     Failed to build PyFITS tile compression support.  PyFITS will still
     function, but without the ability to read or write compressed images.
@@ -143,7 +143,7 @@ fail_message =
 
 
 [global]
-setup-hooks = 
+setup-hooks =
 #    stsci.distutils.hooks.tag_svn_revision
     setup_hooks.py2_only_hook
     stsci.distutils.hooks.version_setup_hook


### PR DESCRIPTION
Once this is merged, before the last release, someone needs to:

* Update change log with the actual release date.
* Tag a release.
* Push release to PyPi (it is not listed in AstroConda).

With this PR:
```python
>>> from pyfits import HDUList
.../pyfits/__init__.py:22: PyFITSDeprecationWarning: PyFITS is deprecated, please use astropy.io.fits
  PyFITSDeprecationWarning)  # noqa
>>> import pyfits  # Subsequent imports don't have warning until warnings filter is reset.
>>> pyfits.__version__
'3.5'
```

c/c @hcferguson @sosey @larrybradley @drdavella 